### PR TITLE
Speed up make by calling flag_glyph_name.py once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,9 @@ FLAGS_DIR = ./flags
 
 glyph_name = $(shell ./flag_glyph_name.py $(flag))
 
+GLYPH_NAMES := $(shell ./flag_glyph_name.py $(FLAGS))
 WAVED_FLAGS := $(foreach flag,$(FLAGS),$(FLAGS_DIR)/$(flag).png)
-PNG128_FLAGS := $(foreach flag,$(FLAGS),$(addprefix ./png/128/emoji_$(glyph_name),.png))
+PNG128_FLAGS := $(foreach glyph_name,$(GLYPH_NAMES),$(addprefix ./png/128/emoji_$(glyph_name),.png))
 
 $(FLAGS_DIR)/%.png: $(FLAGS_SRC_DIR)/%.png ./waveflag $(PNGQUANT)
 	mkdir -p $(FLAGS_DIR)


### PR DESCRIPTION
This script takes ~1 second for startup, so calling it repeatedly for
each flag slows the Makefile considerably, and unnecessarily since it
can be called for all the flags at once.

Now make clean takes about 1.2s, instead of 3m45s.