### PR TITLE
fix add_glyphs to use absolute path when extending sys.path

### DIFF
--- a/third_party/color_emoji/add_glyphs.py
+++ b/third_party/color_emoji/add_glyphs.py
@@ -5,7 +5,8 @@ from fontTools import ttx
 from fontTools.ttLib.tables import otTables
 from png import PNG
 
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../'))
+sys.path.append(
+    os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
 import add_emoji_gsub
 
 

--- a/third_party/color_emoji/add_glyphs.py
+++ b/third_party/color_emoji/add_glyphs.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 
-import glob, sys
+import glob, os, sys
 from fontTools import ttx
 from fontTools.ttLib.tables import otTables
 from png import PNG
 
-sys.path.append('../../')
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../'))
 import add_emoji_gsub
 
 


### PR DESCRIPTION
add_glyphs was failing (for me), the relative path was not working to pick up the package when running make from the project root.