### PR TITLE
Change Makefile to be smarter about dependencies.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ VS_ADDER = add_vs_cmap.py
 	@rm -f "$@"
 	ttx "$<"
 
-$(EMOJI).ttf: $(EMOJI).tmpl.ttf $(EMOJI_BUILDER) $(PUA_ADDER) $(VS_ADDER) \
+$(EMOJI).ttf: $(EMOJI).tmpl.ttf $(EMOJI_BUILDER) $(PUA_ADDER) \
   $(EMOJI_PNG128)*.png $(PNG128_FLAGS)
 	python $(EMOJI_BUILDER) -V $< "$@" $(EMOJI_PNG128)
 	python $(PUA_ADDER) "$@" "$@-with-pua"

--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,12 @@ font: $(EMOJI).ttf
 
 CFLAGS = -std=c99 -Wall -Wextra `pkg-config --cflags --libs cairo`
 LDFLAGS = `pkg-config --libs cairo`
-PNGQUANTDIR := $(abspath `pwd`/../third_party/pngquant)
+PNGQUANTDIR := third_party/pngquant
 PNGQUANT := $(PNGQUANTDIR)/pngquant
 PNGQUANTFLAGS = --speed 1 --skip-if-larger --ext '.png' --force
 
-"$(PNGQUANT)":
-	cd "$(PNGQUANTDIR)" && make
+$(PNGQUANT):
+	$(MAKE) -C $(PNGQUANTDIR)
 
 waveflag: waveflag.c
 	$(CC) $< -o $@ $(CFLAGS) $(LDFLAGS)
@@ -62,11 +62,11 @@ GLYPH_NAMES := $(shell ./flag_glyph_name.py $(FLAGS))
 WAVED_FLAGS := $(foreach flag,$(FLAGS),$(FLAGS_DIR)/$(flag).png)
 PNG128_FLAGS := $(foreach glyph_name,$(GLYPH_NAMES),$(addprefix ./png/128/emoji_$(glyph_name),.png))
 
-$(FLAGS_DIR)/%.png: $(FLAGS_SRC_DIR)/%.png ./waveflag "$(PNGQUANT)"
+$(FLAGS_DIR)/%.png: $(FLAGS_SRC_DIR)/%.png ./waveflag $(PNGQUANT)
 	mkdir -p $(FLAGS_DIR)
 	./waveflag "$<" "$@"
 	optipng -quiet -o7 "$@"
-	"$(PNGQUANT)" $(PNGQUANTFLAGS) "$@"
+	$(PNGQUANT) $(PNGQUANTFLAGS) "$@"
 
 flag-symlinks: $(WAVED_FLAGS)
 	$(subst ^, ,                                \
@@ -85,7 +85,7 @@ ADD_GLYPHS = third_party/color_emoji/add_glyphs.py
 PUA_ADDER = map_pua_emoji.py
 VS_ADDER = add_vs_cmap.py
 
-%.ttx: %.ttx.tmpl $(ADD_GLYPHS) $(UNI) flag-symlinks
+%.ttx: %.ttx.tmpl $(ADD_GLYPHS) $(UNI) $(PNG128_FLAGS)
 	python $(ADD_GLYPHS) "$<" "$@" "$(EMOJI_PNG128)"
 
 %.ttf: %.ttx
@@ -93,7 +93,7 @@ VS_ADDER = add_vs_cmap.py
 	ttx "$<"
 
 $(EMOJI).ttf: $(EMOJI).tmpl.ttf $(EMOJI_BUILDER) $(PUA_ADDER) $(VS_ADDER) \
-  $(EMOJI_PNG128)*.png flag-symlinks
+  $(EMOJI_PNG128)*.png $(PNG128_FLAGS)
 	python $(EMOJI_BUILDER) -V $< "$@" $(EMOJI_PNG128)
 	python $(PUA_ADDER) "$@" "$@-with-pua"
 	$(VS_ADDER) --dstdir '.' -o "$@-with-pua-varsel" "$@-with-pua"

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,9 @@ EMOJI_BUILDER = third_party/color_emoji/emoji_builder.py
 ADD_GLYPHS = third_party/color_emoji/add_glyphs.py
 PUA_ADDER = map_pua_emoji.py
 VS_ADDER = add_vs_cmap.py
+ifeq (, $(shell which $(VS_ADDER)))
+  $(error "$(VS_ADDER) not in path, run setup.py in nototools")
+endif
 
 %.ttx: %.ttx.tmpl $(ADD_GLYPHS) $(UNI) $(PNG128_FLAGS)
 	python $(ADD_GLYPHS) "$<" "$@" "$(EMOJI_PNG128)"


### PR DESCRIPTION
This reverts some changes in commit b257b6647d that were causing build
issues.  Those changes quoted the path to pngquant in order to deal
with spaces in the path, but as a side effect that prevented
build-dependency analysis (gnu 3.81 on ubuntu) from recognizing that
the .png files didn't need to be built, and so rebuilt them every
time, which takes several minutes.  Apparently make doesn't like
quotes-- strings passed to the shell are fine, but things make itself
processes (like names of targets) are treated literally.

Since the path to pngquant is (now, anyway) a local subpath of the
current directory that has no spaces, it should be ok to use the
subpath and not bother to quote.

Another change replaces two dependencies on flag-symlinks with a
dependency on PNG128_FLAGS, for the same reason: after flag-symlinks
executed it was not recognized as being up to date and so the rules
with these dependencies always executed.