### PR TITLE
Update NotoColorEmoji template so that it passes lint, bump version.

### DIFF
--- a/NotoColorEmoji.tmpl.ttx.tmpl
+++ b/NotoColorEmoji.tmpl.ttx.tmpl
@@ -13,7 +13,7 @@
   <head>
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="1.0"/>
-    <fontRevision value="1.23"/>
+    <fontRevision value="1.24"/>
     <checkSumAdjustment value="0x4d5a161a"/>
     <magicNumber value="0x5f0f3cf5"/>
     <flags value="00000000 00001011"/>
@@ -33,9 +33,9 @@
 
   <hhea>
     <tableVersion value="1.0"/>
-    <ascent value="1900"/>
-    <descent value="-500"/>
-    <lineGap value="256"/>
+    <ascent value="2189"/>
+    <descent value="-600"/>
+    <lineGap value="0"/>
     <advanceWidthMax value="2550"/>
     <minLeftSideBearing value="0"/>
     <minRightSideBearing value="0"/>
@@ -73,7 +73,7 @@
   <OS_2>
     <version value="4"/>
     <xAvgCharWidth value="2550"/>
-    <usWeightClass value="500"/>
+    <usWeightClass value="400"/>
     <usWidthClass value="5"/>
     <fsType value="00000000 00000000"/>
     <ySubscriptXSize value="1331"/>
@@ -104,14 +104,14 @@
     <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
     <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
     <achVendID value="GOOG"/>
-    <fsSelection value="00000000 11000000"/>
+    <fsSelection value="00000000 01000000"/>
     <fsFirstCharIndex value="0"/>
     <fsLastCharIndex value="90"/>
-    <sTypoAscender value="1900"/>
-    <sTypoDescender value="-500"/>
-    <sTypoLineGap value="256"/>
-    <usWinAscent value="1900"/>
-    <usWinDescent value="500"/>
+    <sTypoAscender value="2189"/>
+    <sTypoDescender value="-600"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="2189"/>
+    <usWinDescent value="600"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
     <sxHeight value="0"/>
@@ -132,7 +132,7 @@
   <cmap>
     <tableVersion version="0"/>
     <cmap_format_12 platformID="3" platEncID="10" language="0" format="12" reserved="0" length="1" nGroups="1">
-      <map code="0x0" name=".notdef"/><!-- &lt;control> -->
+      <map code="0x0" name="null"/><!-- &lt;control> -->
       <map code="0xd" name="nonmarkingreturn"/>
       <map code="0x20" name="space"/>
       <map code="0x200d" name="u200D"/>
@@ -156,7 +156,7 @@
       Noto Color Emoji
     </namerecord>
     <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
-      Version 1.23
+      Version 1.24
     </namerecord>
     <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
       NotoColorEmoji
@@ -164,7 +164,19 @@
     <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
       Noto is a trademark of Google Inc.
     </namerecord>
+    <namerecord nameID="8" platformID="3" platEncID="1" langID="0x409">
+      Google, Inc.
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      Google, Inc.
+    </namerecord>
+    <namerecord nameID="10" platformID="3" platEncID="1" langID="0x409">
+      Color emoji font using CBDT glyph data.
+    </namerecord>
     <namerecord nameID="11" platformID="3" platEncID="1" langID="0x409">
+      http://www.google.com/get/noto/
+    </namerecord>
+    <namerecord nameID="12" platformID="3" platEncID="1" langID="0x409">
       http://www.google.com/get/noto/
     </namerecord>
     <namerecord nameID="13" platformID="3" platEncID="1" langID="0x409">


### PR DESCRIPTION
- fix ascent/descent in hhea and os/2 to match noto UI expectations,
  zero linegap, clear useTypoMetrics bit, set weight to regular (400).
- add missing entries to name table, update revision
- map U+0000 to null glyph (not .notdef)

In addition, this tweaks the Makefile in some small ways:
- quiet zopflipng output somewhat (listen to your cpu fan to know
  that something's happening) :-)
- make flag-symlinks target an order-only dependency (it was triggering
  quantize+compress even when images hadn't changed)
- add comment about how to bypass make bug if multithread hangs