### PR TITLE
Revert NotoColorEmoji ascent/descent to previous values.

### DIFF
--- a/NotoColorEmoji.tmpl.ttx.tmpl
+++ b/NotoColorEmoji.tmpl.ttx.tmpl
@@ -13,7 +13,7 @@
   <head>
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="1.0"/>
-    <fontRevision value="1.24"/>
+    <fontRevision value="1.25"/>
     <checkSumAdjustment value="0x4d5a161a"/>
     <magicNumber value="0x5f0f3cf5"/>
     <flags value="00000000 00001011"/>
@@ -33,8 +33,8 @@
 
   <hhea>
     <tableVersion value="1.0"/>
-    <ascent value="2189"/>
-    <descent value="-600"/>
+    <ascent value="1900"/>
+    <descent value="-500"/>
     <lineGap value="0"/>
     <advanceWidthMax value="2550"/>
     <minLeftSideBearing value="0"/>
@@ -107,11 +107,11 @@
     <fsSelection value="00000000 01000000"/>
     <fsFirstCharIndex value="0"/>
     <fsLastCharIndex value="90"/>
-    <sTypoAscender value="2189"/>
-    <sTypoDescender value="-600"/>
+    <sTypoAscender value="1900"/>
+    <sTypoDescender value="-500"/>
     <sTypoLineGap value="0"/>
-    <usWinAscent value="2189"/>
-    <usWinDescent value="600"/>
+    <usWinAscent value="1900"/>
+    <usWinDescent value="500"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
     <sxHeight value="0"/>
@@ -156,7 +156,7 @@
       Noto Color Emoji
     </namerecord>
     <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
-      Version 1.24
+      Version 1.25
     </namerecord>
     <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
       NotoColorEmoji


### PR DESCRIPTION
Note, this leaves the linegap at zero.  Bumps the version to 1.25.