### PR TITLE
Update handling of fitzpatrick modifiers.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ $(EMOJI).ttf: $(EMOJI).tmpl.ttf $(EMOJI_BUILDER) $(PUA_ADDER) \
 	$(ALL_COMPRESSED_FILES) | check_vs_adder
 	@python $(EMOJI_BUILDER) -V $< "$@" "$(COMPRESSED_DIR)/emoji_u"
 	@python $(PUA_ADDER) "$@" "$@-with-pua"
-	$(VS_ADDER) --dstdir '.' -o "$@-with-pua-varsel" "$@-with-pua"
+	$(VS_ADDER) -vs 2640 2642 2695 --dstdir '.' -o "$@-with-pua-varsel" "$@-with-pua"
 	mv "$@-with-pua-varsel" "$@"
 	rm "$@-with-pua"
 

--- a/NotoColorEmoji.tmpl.ttx.tmpl
+++ b/NotoColorEmoji.tmpl.ttx.tmpl
@@ -13,7 +13,7 @@
   <head>
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="1.0"/>
-    <fontRevision value="1.32"/>
+    <fontRevision value="1.33"/>
     <checkSumAdjustment value="0x4d5a161a"/>
     <magicNumber value="0x5f0f3cf5"/>
     <flags value="00000000 00001011"/>
@@ -156,7 +156,7 @@
       Noto Color Emoji
     </namerecord>
     <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
-      Version 1.32
+      Version 1.33
     </namerecord>
     <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
       NotoColorEmoji


### PR DESCRIPTION
To handle forming emoji 'ligatures' in RTL contexts we generate
reversed ligature sequences for the GSUB table.  Formerly we only did
this when there was a ZWJ in the sequence, and full reversal worked
because we had no sequences with both fitzpatrick modifiers and ZWJ.
However, now we do.  Harfbuzz treats fitzpatrick modifiers as though
they were combining marks and so we need to as well so that GSUB data
is in the order Harfbuzz expects.  So we 'unreverse' these pairs.