### PR TITLE
Update copyright language in templates.

### DIFF
--- a/NotoColorEmoji.tmpl.ttx.tmpl
+++ b/NotoColorEmoji.tmpl.ttx.tmpl
@@ -141,7 +141,7 @@
 
   <name>
     <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
-      Copyright 2013 Google Inc. All Rights Reserved.
+      Copyright 2013 Google Inc.
     </namerecord>
     <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
       Noto Color Emoji

--- a/NotoColorEmojiSvg.tmpl.ttx
+++ b/NotoColorEmojiSvg.tmpl.ttx
@@ -130,7 +130,7 @@
 
   <name>
     <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
-      Copyright 2015 Google Inc. All Rights Reserved.
+      Copyright 2015 Google Inc.
     </namerecord>
     <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
       Noto Color Emoji SVG
@@ -157,10 +157,10 @@
       http://code.google.com/p/noto/
     </namerecord>
     <namerecord nameID="13" platformID="3" platEncID="1" langID="0x409">
-      Licensed under the Apache License, Version 2.0
+      This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.
     </namerecord>
     <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
-      http://www.apache.org/licenses/LICENSE-2.0
+      http://scripts.sil.org/OFL
     </namerecord>
   </name>
 


### PR DESCRIPTION
"All Rights Reserved." is not meaningful and can be confusing, so it
was removed.

The SVG template was updated to the current OFL copyright language.