### PR TITLE
Replace missing include patch that was inadvertently dropped

### DIFF
--- a/waveflag.c
+++ b/waveflag.c
@@ -17,6 +17,7 @@
  */
 
 #include <cairo.h>
+#include <libgen.h> // basename
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
…when updating from upstream.

Our copy of waveflag.c uses basename and so needs the header.