### PR TITLE
Subregion flag support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ $(RESIZED_FLAGS_DIR)/%.png: $(FLAGS_DIR)/%.png | $(RESIZED_FLAGS_DIR)
 	@convert -extent 136x128 -gravity center -background none "$<" "$@"
 
 flag-symlinks: $(RESIZED_FLAG_FILES) | $(RENAMED_FLAGS_DIR)
-	@$(subst ^, ,                                  \
+	$(subst ^, ,                                  \
 	  $(join                                       \
 	    $(FLAGS:%=ln^-fs^../resized_flags/%.png^), \
 	    $(RENAMED_FLAG_FILES:%=%; )                \

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ $(RESIZED_FLAGS_DIR)/%.png: $(FLAGS_DIR)/%.png | $(RESIZED_FLAGS_DIR)
 	@convert -extent 136x128 -gravity center -background none "$<" "$@"
 
 flag-symlinks: $(RESIZED_FLAG_FILES) | $(RENAMED_FLAGS_DIR)
-	$(subst ^, ,                                  \
+	@$(subst ^, ,                                  \
 	  $(join                                       \
 	    $(FLAGS:%=ln^-fs^../resized_flags/%.png^), \
 	    $(RENAMED_FLAG_FILES:%=%; )                \
@@ -213,7 +213,7 @@ clean:
 	rm -rf $(BUILD_DIR)
 
 .SECONDARY: $(EMOJI_FILES) $(FLAG_FILES) $(RESIZED_FLAG_FILES) $(RENAMED_FLAG_FILES) \
-  $(ALL_QUANTIZED_FILES) $(ALL_COMPRESSED_FILES) NotoColorEmoji.tmpl.ttx
+  $(ALL_QUANTIZED_FILES) $(ALL_COMPRESSED_FILES)
 
 .PHONY:	clean flags emoji renamed_flags quantized compressed check_compress_tool
 

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ clean:
 	rm -rf $(BUILD_DIR)
 
 .SECONDARY: $(EMOJI_FILES) $(FLAG_FILES) $(RESIZED_FLAG_FILES) $(RENAMED_FLAG_FILES) \
-  $(ALL_QUANTIZED_FILES) $(ALL_COMPRESSED_FILES)
+  $(ALL_QUANTIZED_FILES) $(ALL_COMPRESSED_FILES) NotoColorEmoji.tmpl.ttx
 
 .PHONY:	clean flags emoji renamed_flags quantized compressed check_compress_tool
 

--- a/NotoColorEmoji.tmpl.ttx.tmpl
+++ b/NotoColorEmoji.tmpl.ttx.tmpl
@@ -8,6 +8,45 @@
     <GlyphID id="2" name="nonmarkingreturn"/>
     <GlyphID id="3" name="space"/>
     <GlyphID id="4" name="u200D"/>
+    <GlyphID id="5" name="uE0030"/>
+    <GlyphID id="6" name="uE0031"/>
+    <GlyphID id="7" name="uE0032"/>
+    <GlyphID id="8" name="uE0033"/>
+    <GlyphID id="9" name="uE0034"/>
+    <GlyphID id="10" name="uE0035"/>
+    <GlyphID id="11" name="uE0036"/>
+    <GlyphID id="12" name="uE0037"/>
+    <GlyphID id="13" name="uE0038"/>
+    <GlyphID id="14" name="uE0039"/>
+    <GlyphID id="15" name="uE0061"/>
+    <GlyphID id="16" name="uE0062"/>
+    <GlyphID id="17" name="uE0063"/>
+    <GlyphID id="18" name="uE0064"/>
+    <GlyphID id="19" name="uE0065"/>
+    <GlyphID id="20" name="uE0066"/>
+    <GlyphID id="21" name="uE0067"/>
+    <GlyphID id="22" name="uE0068"/>
+    <GlyphID id="23" name="uE0069"/>
+    <GlyphID id="24" name="uE006A"/>
+    <GlyphID id="25" name="uE006B"/>
+    <GlyphID id="26" name="uE006C"/>
+    <GlyphID id="27" name="uE006D"/>
+    <GlyphID id="28" name="uE006E"/>
+    <GlyphID id="29" name="uE006F"/>
+    <GlyphID id="30" name="uE0070"/>
+    <GlyphID id="31" name="uE0071"/>
+    <GlyphID id="32" name="uE0072"/>
+    <GlyphID id="33" name="uE0073"/>
+    <GlyphID id="34" name="uE0074"/>
+    <GlyphID id="35" name="uE0075"/>
+    <GlyphID id="36" name="uE0076"/>
+    <GlyphID id="37" name="uE0077"/>
+    <GlyphID id="38" name="uE0078"/>
+    <GlyphID id="39" name="uE0079"/>
+    <GlyphID id="40" name="uE007A"/>
+    <GlyphID id="41" name="uE007F"/>
+    <GlyphID id="42" name="u1F3F4"/>
+    <GlyphID id="43" name="uFE82B"/>
   </GlyphOrder>
 
   <head>
@@ -127,6 +166,45 @@
     <mtx name="nonmarkingreturn" width="2550" lsb="0"/>
     <mtx name="space" width="2550" lsb="0"/>
     <mtx name="u200D" width="0" lsb="0"/>
+    <mtx name="uE0030" width="0" lsb="0"/>
+    <mtx name="uE0031" width="0" lsb="0"/>
+    <mtx name="uE0032" width="0" lsb="0"/>
+    <mtx name="uE0033" width="0" lsb="0"/>
+    <mtx name="uE0034" width="0" lsb="0"/>
+    <mtx name="uE0035" width="0" lsb="0"/>
+    <mtx name="uE0036" width="0" lsb="0"/>
+    <mtx name="uE0037" width="0" lsb="0"/>
+    <mtx name="uE0038" width="0" lsb="0"/>
+    <mtx name="uE0039" width="0" lsb="0"/>
+    <mtx name="uE0061" width="0" lsb="0"/>
+    <mtx name="uE0062" width="0" lsb="0"/>
+    <mtx name="uE0063" width="0" lsb="0"/>
+    <mtx name="uE0064" width="0" lsb="0"/>
+    <mtx name="uE0065" width="0" lsb="0"/>
+    <mtx name="uE0066" width="0" lsb="0"/>
+    <mtx name="uE0067" width="0" lsb="0"/>
+    <mtx name="uE0068" width="0" lsb="0"/>
+    <mtx name="uE0069" width="0" lsb="0"/>
+    <mtx name="uE006A" width="0" lsb="0"/>
+    <mtx name="uE006B" width="0" lsb="0"/>
+    <mtx name="uE006C" width="0" lsb="0"/>
+    <mtx name="uE006D" width="0" lsb="0"/>
+    <mtx name="uE006E" width="0" lsb="0"/>
+    <mtx name="uE006F" width="0" lsb="0"/>
+    <mtx name="uE0070" width="0" lsb="0"/>
+    <mtx name="uE0071" width="0" lsb="0"/>
+    <mtx name="uE0072" width="0" lsb="0"/>
+    <mtx name="uE0073" width="0" lsb="0"/>
+    <mtx name="uE0074" width="0" lsb="0"/>
+    <mtx name="uE0075" width="0" lsb="0"/>
+    <mtx name="uE0076" width="0" lsb="0"/>
+    <mtx name="uE0077" width="0" lsb="0"/>
+    <mtx name="uE0078" width="0" lsb="0"/>
+    <mtx name="uE0079" width="0" lsb="0"/>
+    <mtx name="uE007A" width="0" lsb="0"/>
+    <mtx name="uE007F" width="0" lsb="0"/>
+    <mtx name="u1F3F4" width="0" lsb="0"/>
+    <mtx name="uFE82B" width="0" lsb="0"/>
   </hmtx>
 
   <cmap>
@@ -136,6 +214,45 @@
       <map code="0xd" name="nonmarkingreturn"/>
       <map code="0x20" name="space"/>
       <map code="0x200d" name="u200D"/>
+      <map code="0xE0030" name="uE0030"/>
+      <map code="0xE0031" name="uE0031"/>
+      <map code="0xE0032" name="uE0032"/>
+      <map code="0xE0033" name="uE0033"/>
+      <map code="0xE0034" name="uE0034"/>
+      <map code="0xE0035" name="uE0035"/>
+      <map code="0xE0036" name="uE0036"/>
+      <map code="0xE0037" name="uE0037"/>
+      <map code="0xE0038" name="uE0038"/>
+      <map code="0xE0039" name="uE0039"/>
+      <map code="0xE0061" name="uE0061"/>
+      <map code="0xE0062" name="uE0062"/>
+      <map code="0xE0063" name="uE0063"/>
+      <map code="0xE0064" name="uE0064"/>
+      <map code="0xE0065" name="uE0065"/>
+      <map code="0xE0066" name="uE0066"/>
+      <map code="0xE0067" name="uE0067"/>
+      <map code="0xE0068" name="uE0068"/>
+      <map code="0xE0069" name="uE0069"/>
+      <map code="0xE006A" name="uE006A"/>
+      <map code="0xE006B" name="uE006B"/>
+      <map code="0xE006C" name="uE006C"/>
+      <map code="0xE006D" name="uE006D"/>
+      <map code="0xE006E" name="uE006E"/>
+      <map code="0xE006F" name="uE006F"/>
+      <map code="0xE0070" name="uE0070"/>
+      <map code="0xE0071" name="uE0071"/>
+      <map code="0xE0072" name="uE0072"/>
+      <map code="0xE0073" name="uE0073"/>
+      <map code="0xE0074" name="uE0074"/>
+      <map code="0xE0075" name="uE0075"/>
+      <map code="0xE0076" name="uE0076"/>
+      <map code="0xE0077" name="uE0077"/>
+      <map code="0xE0078" name="uE0078"/>
+      <map code="0xE0079" name="uE0079"/>
+      <map code="0xE007A" name="uE007A"/>
+      <map code="0xE007F" name="uE007F"/>
+      <map code="0x1F3F4" name="u1F3F4"/>
+      <map code="0xFE82B" name="uFE82B"/>
     </cmap_format_12>
   </cmap>
 
@@ -198,5 +315,204 @@
     <minMemType1 value="0"/>
     <maxMemType1 value="0"/>
   </post>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="ccmp"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+          <LookupListIndex index="1" value="2"/>
+          <LookupListIndex index="2" value="3"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="4"/>
+        <!-- LookupType=4 -->
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0" Format="1">
+        </LigatureSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <MultipleSubst index="0" Format="1">
+          <Substitution in="uE0030" out=""/>
+          <Substitution in="uE0031" out=""/>
+          <Substitution in="uE0032" out=""/>
+          <Substitution in="uE0033" out=""/>
+          <Substitution in="uE0034" out=""/>
+          <Substitution in="uE0035" out=""/>
+          <Substitution in="uE0036" out=""/>
+          <Substitution in="uE0037" out=""/>
+          <Substitution in="uE0038" out=""/>
+          <Substitution in="uE0039" out=""/>
+          <Substitution in="uE0061" out=""/>
+          <Substitution in="uE0062" out=""/>
+          <Substitution in="uE0063" out=""/>
+          <Substitution in="uE0064" out=""/>
+          <Substitution in="uE0065" out=""/>
+          <Substitution in="uE0066" out=""/>
+          <Substitution in="uE0067" out=""/>
+          <Substitution in="uE0068" out=""/>
+          <Substitution in="uE0069" out=""/>
+          <Substitution in="uE006A" out=""/>
+          <Substitution in="uE006B" out=""/>
+          <Substitution in="uE006C" out=""/>
+          <Substitution in="uE006D" out=""/>
+          <Substitution in="uE006E" out=""/>
+          <Substitution in="uE006F" out=""/>
+          <Substitution in="uE0070" out=""/>
+          <Substitution in="uE0071" out=""/>
+          <Substitution in="uE0072" out=""/>
+          <Substitution in="uE0073" out=""/>
+          <Substitution in="uE0074" out=""/>
+          <Substitution in="uE0075" out=""/>
+          <Substitution in="uE0076" out=""/>
+          <Substitution in="uE0077" out=""/>
+          <Substitution in="uE0078" out=""/>
+          <Substitution in="uE0079" out=""/>
+          <Substitution in="uE007A" out=""/>
+        </MultipleSubst>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="6"/>
+        <!-- LookupType=6 -->
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <ChainContextSubst index="0" Format="2">
+          <Coverage Format="2">
+            <Glyph value="uE0030"/>
+            <Glyph value="uE0031"/>
+            <Glyph value="uE0032"/>
+            <Glyph value="uE0033"/>
+            <Glyph value="uE0034"/>
+            <Glyph value="uE0035"/>
+            <Glyph value="uE0036"/>
+            <Glyph value="uE0037"/>
+            <Glyph value="uE0038"/>
+            <Glyph value="uE0039"/>
+            <Glyph value="uE0061"/>
+            <Glyph value="uE0062"/>
+            <Glyph value="uE0063"/>
+            <Glyph value="uE0064"/>
+            <Glyph value="uE0065"/>
+            <Glyph value="uE0066"/>
+            <Glyph value="uE0067"/>
+            <Glyph value="uE0068"/>
+            <Glyph value="uE0069"/>
+            <Glyph value="uE006A"/>
+            <Glyph value="uE006B"/>
+            <Glyph value="uE006C"/>
+            <Glyph value="uE006D"/>
+            <Glyph value="uE006E"/>
+            <Glyph value="uE006F"/>
+            <Glyph value="uE0070"/>
+            <Glyph value="uE0071"/>
+            <Glyph value="uE0072"/>
+            <Glyph value="uE0073"/>
+            <Glyph value="uE0074"/>
+            <Glyph value="uE0075"/>
+            <Glyph value="uE0076"/>
+            <Glyph value="uE0077"/>
+            <Glyph value="uE0078"/>
+            <Glyph value="uE0079"/>
+            <Glyph value="uE007A"/>
+          </Coverage>
+          <BacktrackClassDef Format="1">
+            <ClassDef glyph="u1F3F4" class="1"/>
+          </BacktrackClassDef>
+          <InputClassDef Format="2">
+            <ClassDef glyph="uE0030" class="2"/>
+            <ClassDef glyph="uE0031" class="2"/>
+            <ClassDef glyph="uE0032" class="2"/>
+            <ClassDef glyph="uE0033" class="2"/>
+            <ClassDef glyph="uE0034" class="2"/>
+            <ClassDef glyph="uE0035" class="2"/>
+            <ClassDef glyph="uE0036" class="2"/>
+            <ClassDef glyph="uE0037" class="2"/>
+            <ClassDef glyph="uE0038" class="2"/>
+            <ClassDef glyph="uE0039" class="2"/>
+            <ClassDef glyph="uE0061" class="2"/>
+            <ClassDef glyph="uE0062" class="2"/>
+            <ClassDef glyph="uE0063" class="2"/>
+            <ClassDef glyph="uE0064" class="2"/>
+            <ClassDef glyph="uE0065" class="2"/>
+            <ClassDef glyph="uE0066" class="2"/>
+            <ClassDef glyph="uE0067" class="2"/>
+            <ClassDef glyph="uE0068" class="2"/>
+            <ClassDef glyph="uE0069" class="2"/>
+            <ClassDef glyph="uE006A" class="2"/>
+            <ClassDef glyph="uE006B" class="2"/>
+            <ClassDef glyph="uE006C" class="2"/>
+            <ClassDef glyph="uE006D" class="2"/>
+            <ClassDef glyph="uE006E" class="2"/>
+            <ClassDef glyph="uE006F" class="2"/>
+            <ClassDef glyph="uE0070" class="2"/>
+            <ClassDef glyph="uE0071" class="2"/>
+            <ClassDef glyph="uE0072" class="2"/>
+            <ClassDef glyph="uE0073" class="2"/>
+            <ClassDef glyph="uE0074" class="2"/>
+            <ClassDef glyph="uE0075" class="2"/>
+            <ClassDef glyph="uE0076" class="2"/>
+            <ClassDef glyph="uE0077" class="2"/>
+            <ClassDef glyph="uE0078" class="2"/>
+            <ClassDef glyph="uE0079" class="2"/>
+            <ClassDef glyph="uE007A" class="2"/>
+          </InputClassDef>
+          <LookAheadClassDef Format="2">
+          </LookAheadClassDef>
+          <!-- ChainSubClassSetCount=3 -->
+          <ChainSubClassSet index="0" empty="1"/>
+          <ChainSubClassSet index="1" empty="1"/>
+          <ChainSubClassSet index="2">
+            <!-- ChainSubClassRuleCount=1 -->
+            <ChainSubClassRule index="0">
+              <!-- BacktrackGlyphCount=1 -->
+              <Backtrack index="0" value="1"/>
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=0 -->
+              <!-- SubstCount=2 -->
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </SubstLookupRecord>
+            </ChainSubClassRule>
+          </ChainSubClassSet>
+        </ChainContextSubst>
+      </Lookup>
+      <Lookup index="3">
+        <LookupType value="4"/>
+        <LookupFlag value="0"/>
+        <LigatureSubst index="0" Format="1">
+          <LigatureSet glyph="u1F3F4">
+            <Ligature components="uE007F" glyph="uFE82B"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
 
 </ttFont>

--- a/NotoColorEmoji.tmpl.ttx.tmpl
+++ b/NotoColorEmoji.tmpl.ttx.tmpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="2.3">
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.6">
 
   <GlyphOrder>
     <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
@@ -47,6 +47,32 @@
     <GlyphID id="41" name="uE007F"/>
     <GlyphID id="42" name="u1F3F4"/>
     <GlyphID id="43" name="uFE82B"/>
+    <GlyphID id="44" name="u1F1E6"/>
+    <GlyphID id="45" name="u1F1E7"/>
+    <GlyphID id="46" name="u1F1E8"/>
+    <GlyphID id="47" name="u1F1E9"/>
+    <GlyphID id="48" name="u1F1EA"/>
+    <GlyphID id="49" name="u1F1EB"/>
+    <GlyphID id="50" name="u1F1EC"/>
+    <GlyphID id="51" name="u1F1ED"/>
+    <GlyphID id="52" name="u1F1EE"/>
+    <GlyphID id="53" name="u1F1EF"/>
+    <GlyphID id="54" name="u1F1F0"/>
+    <GlyphID id="55" name="u1F1F1"/>
+    <GlyphID id="56" name="u1F1F2"/>
+    <GlyphID id="57" name="u1F1F3"/>
+    <GlyphID id="58" name="u1F1F4"/>
+    <GlyphID id="59" name="u1F1F5"/>
+    <GlyphID id="60" name="u1F1F6"/>
+    <GlyphID id="61" name="u1F1F7"/>
+    <GlyphID id="62" name="u1F1F8"/>
+    <GlyphID id="63" name="u1F1F9"/>
+    <GlyphID id="64" name="u1F1FA"/>
+    <GlyphID id="65" name="u1F1FB"/>
+    <GlyphID id="66" name="u1F1FC"/>
+    <GlyphID id="67" name="u1F1FD"/>
+    <GlyphID id="68" name="u1F1FE"/>
+    <GlyphID id="69" name="u1F1FF"/>
   </GlyphOrder>
 
   <head>
@@ -71,7 +97,7 @@
   </head>
 
   <hhea>
-    <tableVersion value="1.0"/>
+    <tableVersion value="0x00010000"/>
     <ascent value="1900"/>
     <descent value="-500"/>
     <lineGap value="0"/>
@@ -93,7 +119,7 @@
   <maxp>
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="0x10000"/>
-    <numGlyphs value="30"/>
+    <numGlyphs value="70"/>
     <maxPoints value="8"/>
     <maxContours value="2"/>
     <maxCompositePoints value="0"/>
@@ -144,8 +170,8 @@
     <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
     <achVendID value="GOOG"/>
     <fsSelection value="00000000 01000000"/>
-    <fsFirstCharIndex value="0"/>
-    <fsLastCharIndex value="90"/>
+    <usFirstCharIndex value="0"/>
+    <usLastCharIndex value="65535"/>
     <sTypoAscender value="1900"/>
     <sTypoDescender value="-500"/>
     <sTypoLineGap value="0"/>
@@ -157,7 +183,7 @@
     <sCapHeight value="1900"/>
     <usDefaultChar value="0"/>
     <usBreakChar value="32"/>
-    <usMaxContex value="1"/>
+    <usMaxContext value="1"/>
   </OS_2>
 
   <hmtx>
@@ -205,6 +231,32 @@
     <mtx name="uE007F" width="0" lsb="0"/>
     <mtx name="u1F3F4" width="0" lsb="0"/>
     <mtx name="uFE82B" width="0" lsb="0"/>
+    <mtx name="u1F1E6" width="0" lsb="0"/>
+    <mtx name="u1F1E7" width="0" lsb="0"/>
+    <mtx name="u1F1E8" width="0" lsb="0"/>
+    <mtx name="u1F1E9" width="0" lsb="0"/>
+    <mtx name="u1F1EA" width="0" lsb="0"/>
+    <mtx name="u1F1EB" width="0" lsb="0"/>
+    <mtx name="u1F1EC" width="0" lsb="0"/>
+    <mtx name="u1F1ED" width="0" lsb="0"/>
+    <mtx name="u1F1EE" width="0" lsb="0"/>
+    <mtx name="u1F1EF" width="0" lsb="0"/>
+    <mtx name="u1F1F0" width="0" lsb="0"/>
+    <mtx name="u1F1F1" width="0" lsb="0"/>
+    <mtx name="u1F1F2" width="0" lsb="0"/>
+    <mtx name="u1F1F3" width="0" lsb="0"/>
+    <mtx name="u1F1F4" width="0" lsb="0"/>
+    <mtx name="u1F1F5" width="0" lsb="0"/>
+    <mtx name="u1F1F6" width="0" lsb="0"/>
+    <mtx name="u1F1F7" width="0" lsb="0"/>
+    <mtx name="u1F1F8" width="0" lsb="0"/>
+    <mtx name="u1F1F9" width="0" lsb="0"/>
+    <mtx name="u1F1FA" width="0" lsb="0"/>
+    <mtx name="u1F1FB" width="0" lsb="0"/>
+    <mtx name="u1F1FC" width="0" lsb="0"/>
+    <mtx name="u1F1FD" width="0" lsb="0"/>
+    <mtx name="u1F1FE" width="0" lsb="0"/>
+    <mtx name="u1F1FF" width="0" lsb="0"/>
   </hmtx>
 
   <cmap>
@@ -253,6 +305,32 @@
       <map code="0xE007F" name="uE007F"/>
       <map code="0x1F3F4" name="u1F3F4"/>
       <map code="0xFE82B" name="uFE82B"/>
+      <map code="0x1F1E6" name="u1F1E6"/>
+      <map code="0x1F1E7" name="u1F1E7"/>
+      <map code="0x1F1E8" name="u1F1E8"/>
+      <map code="0x1F1E9" name="u1F1E9"/>
+      <map code="0x1F1EA" name="u1F1EA"/>
+      <map code="0x1F1EB" name="u1F1EB"/>
+      <map code="0x1F1EC" name="u1F1EC"/>
+      <map code="0x1F1ED" name="u1F1ED"/>
+      <map code="0x1F1EE" name="u1F1EE"/>
+      <map code="0x1F1EF" name="u1F1EF"/>
+      <map code="0x1F1F0" name="u1F1F0"/>
+      <map code="0x1F1F1" name="u1F1F1"/>
+      <map code="0x1F1F2" name="u1F1F2"/>
+      <map code="0x1F1F3" name="u1F1F3"/>
+      <map code="0x1F1F4" name="u1F1F4"/>
+      <map code="0x1F1F5" name="u1F1F5"/>
+      <map code="0x1F1F6" name="u1F1F6"/>
+      <map code="0x1F1F7" name="u1F1F7"/>
+      <map code="0x1F1F8" name="u1F1F8"/>
+      <map code="0x1F1F9" name="u1F1F9"/>
+      <map code="0x1F1FA" name="u1F1FA"/>
+      <map code="0x1F1FB" name="u1F1FB"/>
+      <map code="0x1F1FC" name="u1F1FC"/>
+      <map code="0x1F1FD" name="u1F1FD"/>
+      <map code="0x1F1FE" name="u1F1FE"/>
+      <map code="0x1F1FF" name="u1F1FF"/>
     </cmap_format_12>
   </cmap>
 
@@ -337,18 +415,18 @@
       <FeatureRecord index="0">
         <FeatureTag value="ccmp"/>
         <Feature>
-          <!-- LookupCount=1 -->
+          <!-- LookupCount=4 -->
           <LookupListIndex index="0" value="0"/>
           <LookupListIndex index="1" value="2"/>
           <LookupListIndex index="2" value="3"/>
+          <LookupListIndex index="3" value="4"/>
         </Feature>
       </FeatureRecord>
     </FeatureList>
     <LookupList>
-      <!-- LookupCount=1 -->
+      <!-- LookupCount=5 -->
       <Lookup index="0">
         <LookupType value="4"/>
-        <!-- LookupType=4 -->
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
@@ -359,6 +437,32 @@
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <MultipleSubst index="0" Format="1">
+          <Substitution in="u1F1E6" out=""/>
+          <Substitution in="u1F1E7" out=""/>
+          <Substitution in="u1F1E8" out=""/>
+          <Substitution in="u1F1E9" out=""/>
+          <Substitution in="u1F1EA" out=""/>
+          <Substitution in="u1F1EB" out=""/>
+          <Substitution in="u1F1EC" out=""/>
+          <Substitution in="u1F1ED" out=""/>
+          <Substitution in="u1F1EE" out=""/>
+          <Substitution in="u1F1EF" out=""/>
+          <Substitution in="u1F1F0" out=""/>
+          <Substitution in="u1F1F1" out=""/>
+          <Substitution in="u1F1F2" out=""/>
+          <Substitution in="u1F1F3" out=""/>
+          <Substitution in="u1F1F4" out=""/>
+          <Substitution in="u1F1F5" out=""/>
+          <Substitution in="u1F1F6" out=""/>
+          <Substitution in="u1F1F7" out=""/>
+          <Substitution in="u1F1F8" out=""/>
+          <Substitution in="u1F1F9" out=""/>
+          <Substitution in="u1F1FA" out=""/>
+          <Substitution in="u1F1FB" out=""/>
+          <Substitution in="u1F1FC" out=""/>
+          <Substitution in="u1F1FD" out=""/>
+          <Substitution in="u1F1FE" out=""/>
+          <Substitution in="u1F1FF" out=""/>
           <Substitution in="uE0030" out=""/>
           <Substitution in="uE0031" out=""/>
           <Substitution in="uE0032" out=""/>
@@ -399,7 +503,6 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="6"/>
-        <!-- LookupType=6 -->
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <ChainContextSubst index="0" Format="2">
@@ -495,7 +598,7 @@
               <Backtrack index="0" value="1"/>
               <!-- InputGlyphCount=1 -->
               <!-- LookAheadGlyphCount=0 -->
-              <!-- SubstCount=2 -->
+              <!-- SubstCount=1 -->
               <SubstLookupRecord index="0">
                 <SequenceIndex value="0"/>
                 <LookupListIndex value="1"/>
@@ -507,6 +610,7 @@
       <Lookup index="3">
         <LookupType value="4"/>
         <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="u1F3F4">
             <Ligature components="uE007F" glyph="uFE82B"/>
@@ -515,6 +619,119 @@
             <Ligature components="u1F3F4" glyph="uFE82B"/>
           </LigatureSet>
         </LigatureSubst>
+      </Lookup>
+      <Lookup index="4">
+        <LookupType value="5"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <ContextSubst index="0" Format="2">
+          <Coverage Format="2">
+            <Glyph value="u1F1E6"/>
+            <Glyph value="u1F1E7"/>
+            <Glyph value="u1F1E8"/>
+            <Glyph value="u1F1E9"/>
+            <Glyph value="u1F1EA"/>
+            <Glyph value="u1F1EB"/>
+            <Glyph value="u1F1EC"/>
+            <Glyph value="u1F1ED"/>
+            <Glyph value="u1F1EE"/>
+            <Glyph value="u1F1EF"/>
+            <Glyph value="u1F1F0"/>
+            <Glyph value="u1F1F1"/>
+            <Glyph value="u1F1F2"/>
+            <Glyph value="u1F1F3"/>
+            <Glyph value="u1F1F4"/>
+            <Glyph value="u1F1F5"/>
+            <Glyph value="u1F1F6"/>
+            <Glyph value="u1F1F7"/>
+            <Glyph value="u1F1F8"/>
+            <Glyph value="u1F1F9"/>
+            <Glyph value="u1F1FA"/>
+            <Glyph value="u1F1FB"/>
+            <Glyph value="u1F1FC"/>
+            <Glyph value="u1F1FD"/>
+            <Glyph value="u1F1FE"/>
+            <Glyph value="u1F1FF"/>
+          </Coverage>
+          <ClassDef Format="2">
+            <ClassDef glyph="u1F1E6" class="1"/>
+            <ClassDef glyph="u1F1E7" class="1"/>
+            <ClassDef glyph="u1F1E8" class="1"/>
+            <ClassDef glyph="u1F1E9" class="1"/>
+            <ClassDef glyph="u1F1EA" class="1"/>
+            <ClassDef glyph="u1F1EB" class="1"/>
+            <ClassDef glyph="u1F1EC" class="1"/>
+            <ClassDef glyph="u1F1ED" class="1"/>
+            <ClassDef glyph="u1F1EE" class="1"/>
+            <ClassDef glyph="u1F1EF" class="1"/>
+            <ClassDef glyph="u1F1F0" class="1"/>
+            <ClassDef glyph="u1F1F1" class="1"/>
+            <ClassDef glyph="u1F1F2" class="1"/>
+            <ClassDef glyph="u1F1F3" class="1"/>
+            <ClassDef glyph="u1F1F4" class="1"/>
+            <ClassDef glyph="u1F1F5" class="1"/>
+            <ClassDef glyph="u1F1F6" class="1"/>
+            <ClassDef glyph="u1F1F7" class="1"/>
+            <ClassDef glyph="u1F1F8" class="1"/>
+            <ClassDef glyph="u1F1F9" class="1"/>
+            <ClassDef glyph="u1F1FA" class="1"/>
+            <ClassDef glyph="u1F1FB" class="1"/>
+            <ClassDef glyph="u1F1FC" class="1"/>
+            <ClassDef glyph="u1F1FD" class="1"/>
+            <ClassDef glyph="u1F1FE" class="1"/>
+            <ClassDef glyph="u1F1FF" class="1"/>
+          </ClassDef>
+          <!-- SubClassSetCount=2 -->
+          <SubClassSet index="0" empty="1"/>
+          <SubClassSet index="1">
+            <!-- SubClassRuleCount=1 -->
+            <SubClassRule index="0">
+              <!-- GlyphCount=2 -->
+              <!-- SubstCount=2 -->
+              <Class index="0" value="1"/>
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="5"/>
+              </SubstLookupRecord>
+              <SubstLookupRecord index="1">
+                <SequenceIndex value="1"/>
+                <LookupListIndex value="1"/>
+              </SubstLookupRecord>
+            </SubClassRule>
+          </SubClassSet>
+        </ContextSubst>
+      </Lookup>
+      <Lookup index="5">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <SingleSubst index="0" Format="1">
+          <Substitution in="u1F1E6" out="uFE82B"/>
+          <Substitution in="u1F1E7" out="uFE82B"/>
+          <Substitution in="u1F1E8" out="uFE82B"/>
+          <Substitution in="u1F1E9" out="uFE82B"/>
+          <Substitution in="u1F1EA" out="uFE82B"/>
+          <Substitution in="u1F1EB" out="uFE82B"/>
+          <Substitution in="u1F1EC" out="uFE82B"/>
+          <Substitution in="u1F1ED" out="uFE82B"/>
+          <Substitution in="u1F1EE" out="uFE82B"/>
+          <Substitution in="u1F1EF" out="uFE82B"/>
+          <Substitution in="u1F1F0" out="uFE82B"/>
+          <Substitution in="u1F1F1" out="uFE82B"/>
+          <Substitution in="u1F1F2" out="uFE82B"/>
+          <Substitution in="u1F1F3" out="uFE82B"/>
+          <Substitution in="u1F1F4" out="uFE82B"/>
+          <Substitution in="u1F1F5" out="uFE82B"/>
+          <Substitution in="u1F1F6" out="uFE82B"/>
+          <Substitution in="u1F1F7" out="uFE82B"/>
+          <Substitution in="u1F1F8" out="uFE82B"/>
+          <Substitution in="u1F1F9" out="uFE82B"/>
+          <Substitution in="u1F1FA" out="uFE82B"/>
+          <Substitution in="u1F1FB" out="uFE82B"/>
+          <Substitution in="u1F1FC" out="uFE82B"/>
+          <Substitution in="u1F1FD" out="uFE82B"/>
+          <Substitution in="u1F1FE" out="uFE82B"/>
+          <Substitution in="u1F1FF" out="uFE82B"/>
+        </SingleSubst>
       </Lookup>
     </LookupList>
   </GSUB>

--- a/NotoColorEmoji.tmpl.ttx.tmpl
+++ b/NotoColorEmoji.tmpl.ttx.tmpl
@@ -443,6 +443,7 @@
           </Coverage>
           <BacktrackClassDef Format="1">
             <ClassDef glyph="u1F3F4" class="1"/>
+            <ClassDef glyph="uE007F" class="1"/>
           </BacktrackClassDef>
           <InputClassDef Format="2">
             <ClassDef glyph="uE0030" class="2"/>
@@ -509,6 +510,9 @@
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="u1F3F4">
             <Ligature components="uE007F" glyph="uFE82B"/>
+          </LigatureSet>
+          <LigatureSet glyph="uE007F">
+            <Ligature components="u1F3F4" glyph="uFE82B"/>
           </LigatureSet>
         </LigatureSubst>
       </Lookup>

--- a/third_party/color_emoji/add_glyphs.py
+++ b/third_party/color_emoji/add_glyphs.py
@@ -204,7 +204,8 @@ for (u, filename) in img_pairs:
                 cp = ord(char)
 		if cp not in c and not is_vs(cp):
 			name = glyph_name (char)
-                        g.append(name)
+                        if name not in glyph_names:
+                                g.append(name)
 			c[cp] = name
 			if len (u) > 1:
 				h[name] = [0, 0]

--- a/third_party/color_emoji/add_glyphs.py
+++ b/third_party/color_emoji/add_glyphs.py
@@ -59,8 +59,17 @@ def add_ligature (font, seq, name):
 		font['GSUB'] = add_emoji_gsub.create_simple_gsub([lookup])
 	else:
 		lookup = font['GSUB'].table.LookupList.Lookup[0]
-		assert lookup.LookupType == 4
+		# assert lookup.LookupType == 4
 		assert lookup.LookupFlag == 0
+
+                # importXML doesn't fully init GSUB structures, so help it out
+                if not hasattr(lookup, 'LookupType'):
+                    st = lookup.SubTable[0]
+                    assert st.LookupType == 4
+                    setattr(lookup, 'LookupType', 4)
+
+                    if not hasattr(st, 'ligatures'):
+                        setattr(st, 'ligatures', {})
 
 	ligatures = lookup.SubTable[0].ligatures
 

--- a/third_party/color_emoji/add_glyphs.py
+++ b/third_party/color_emoji/add_glyphs.py
@@ -160,7 +160,7 @@ glyph_names = set()
 ligatures = {}
 
 def add_lig_sequence(ligatures, seq, n):
-        # We have emoji sequences using regional indicator symbols,
+        # We have emoji sequences using regional indicator symbols, tags,
         # ZWJ, fitzpatrick modifiers, and combinations of ZWJ and fitzpatrick
         # modifiers.  Currently, Harfbuzz special-cases the fitzpatrick
         # modifiers to treat them as combining marks instead of as Other
@@ -169,10 +169,10 @@ def add_lig_sequence(ligatures, seq, n):
         # emoji sequences in an RTL context we need GSUB sequences that match
         # this order.
         # Regional indicator symbols are LTR, and emoji+fitzpatrick are
-        # effectively LTR, so we only reorder sequences with ZWJ.  If however
-        # the ZWJ sequence has fitzpatrick modifiers, those need to still follow
-        # the emoji they logically follow, so simply reversing the sequence
-        # doesn't work.  This code assumes the lig sequence is valid.
+        # effectively LTR, so we only reorder sequences with ZWJ or tags.  If
+        # however the ZWJ sequence has fitzpatrick modifiers, those need to
+        # still follow the emoji they logically follow, so simply reversing the
+        # sequence doesn't work.  This code assumes the lig sequence is valid.
         tseq = tuple(seq)
         if tseq in ligatures:
                 print 'lig sequence %s, replace %s with %s' % (
@@ -260,15 +260,6 @@ if have_flags:
     seq = _reg_lig_sequence(flag_from)
     name = _reg_lig_name(flag_to)
     add_lig_sequence(ligatures, seq, name)
-
-  print 'Adding unused flag sequences'
-  # every flag sequence we don't have gets the missing flag glyph
-  for first in regional_names:
-    for second in regional_names:
-      seq = (first, second)
-      if seq not in ligatures:
-        add_lig_sequence(ligatures, seq, UNKNOWN_FLAG_GLYPH_NAME)
-
 
 keyed_ligatures = collections.defaultdict(list)
 for k, v in ligatures.iteritems():

--- a/third_party/color_emoji/add_glyphs.py
+++ b/third_party/color_emoji/add_glyphs.py
@@ -178,7 +178,7 @@ def add_lig_sequence(ligatures, seq, n):
                 print 'lig sequence %s, replace %s with %s' % (
                     tseq, ligatures[tseq], n)
         ligatures[tseq] = n
-        if 'u200D' in seq:
+        if 'u200D' in seq or 'uE007F' in seq:
                 rev_seq = seq[:]
                 rev_seq.reverse()
                 for i in xrange(1, len(rev_seq)):


### PR DESCRIPTION
A number of related changes based on supporting subregion flags.

- The start character was changed from waving white flag to waving black flag
- Handled subregion sequences in rtl order
- The template was significantly extended to provide default GSUB tables to handle fallback of unrecognized subregion flag sequences to the unknown flag.  Note, ttx currently isn't quite reading/writing these correctly, so there are some minor workarounds in the template and in the code to fix up the GSUB object structure.
- Formerly fallback to the unknown flag for regions using regional indicator symbol pairs was implemented by forming a ligature for each possible pair.  Now instead of adding those, template GSUB rules were added to do this fallback as well.
- Updated the template to match what is output by more current versions of ttx, and fixes a typo.