### PR TITLE
Fix scripts that auto-invoke python to find it correctly.

### DIFF
--- a/generate_emoji_html.py
+++ b/generate_emoji_html.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2016 Google Inc. All rights reserved.
 #

--- a/materialize_emoji_images.py
+++ b/materialize_emoji_images.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2016 Google Inc. All rights reserved.
 #


### PR DESCRIPTION
Some of our environments use python from /usr/local/bin. In these
environments using /usr/bin/python can cause unexpected behavior
since the python module search path is different.  So use env
to find python using the PATH instead.