### PR TITLE
Update Noto Color Emoji font to 1.39.

### DIFF
--- a/NotoColorEmoji.tmpl.ttx.tmpl
+++ b/NotoColorEmoji.tmpl.ttx.tmpl
@@ -78,7 +78,7 @@
   <head>
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="1.0"/>
-    <fontRevision value="1.37"/>
+    <fontRevision value="1.39"/>
     <checkSumAdjustment value="0x4d5a161a"/>
     <magicNumber value="0x5f0f3cf5"/>
     <flags value="00000000 00001011"/>
@@ -246,7 +246,7 @@
       Noto Color Emoji
     </namerecord>
     <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
-      Version 1.37
+      Version 1.39;GOOG;noto-emoji:20170518:009916646ea7
     </namerecord>
     <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
       NotoColorEmoji


### PR DESCRIPTION
This fixes the skin tones of the light/medium light male cook emoji,
which had been swapped.