### PR TITLE
Fix emoji thumbnail generation to prevent grayscale pngs.

### DIFF
--- a/generate_emoji_thumbnails.py
+++ b/generate_emoji_thumbnails.py
@@ -38,10 +38,10 @@ logger = logging.getLogger('emoji_thumbnails')
 
 def create_thumbnail(src_path, dst_path):
   # uses imagemagik
-  # we need imagex exactly 72x72 in size, with transparent background
+  # we need images exactly 72x72 in size, with transparent background
   subprocess.check_call([
       'convert', '-thumbnail', '72x72', '-gravity', 'center', '-background',
-      'none', '-extent', '72x72', src_path, dst_path])
+      'none', '-extent', '72x72', src_path, 'PNG32:' + dst_path])
 
 
 def get_inv_aliases():


### PR DESCRIPTION
Same problem that we ran into previously with the emoji font--
imagemagick takes RGBA that contain only grayscale and converts
to grayscale with alpha, but although it can display these ok,
chrome can't.  So force it to generate RGBA output.