### PR TITLE
Add collect_glyphstr_file_pairs(verbosity=1) param

### DIFF
--- a/add_svg_glyphs.py
+++ b/add_svg_glyphs.py
@@ -171,7 +171,7 @@ class FontBuilder(object):
     self.svgs.append(svg_record)
 
 
-def collect_glyphstr_file_pairs(prefix, ext, include=None, exclude=None):
+def collect_glyphstr_file_pairs(prefix, ext, include=None, exclude=None, verbosity=1):
   """Scan files with the given prefix and extension, and return a list of
   (glyphstr, filename) where glyphstr is the character or ligature, and filename
   is the image file associated with it.  The glyphstr is formed by decoding the
@@ -199,7 +199,7 @@ def collect_glyphstr_file_pairs(prefix, ext, include=None, exclude=None):
 
     if ex and ex.search(image_file):
       if verbosity > 1:
-        print "Exclude %s" % image_file
+        print("Exclude %s" % image_file)
       ex_count += 1
       continue
 


### PR DESCRIPTION
Currently `verbosity` is an undefined name and line 201 will raise a `NameError` when executed.  The only other place in this repo where `verbosity` is defined is as a function parameter to [do_generate_test_html()](https://github.com/googlei18n/noto-emoji/blob/5e1808fbbe36f6461a68417f4573898917295ffc/generate_test_html.py#L28) with a default value of `verbosity=1`.

Someone who really understands the functioning of this code should __carefully review this change before merging it__.  My sense is that this approach is better than raising a NameError but perhaps I am all wet.