### PR TITLE
Regenerate emoji font with fixed PNGs.

### DIFF
--- a/NotoColorEmoji.tmpl.ttx.tmpl
+++ b/NotoColorEmoji.tmpl.ttx.tmpl
@@ -78,7 +78,7 @@
   <head>
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="1.0"/>
-    <fontRevision value="2.001"/>
+    <fontRevision value="2.002"/>
     <checkSumAdjustment value="0x4d5a161a"/>
     <magicNumber value="0x5f0f3cf5"/>
     <flags value="00000000 00001011"/>
@@ -246,7 +246,7 @@
       Noto Color Emoji
     </namerecord>
     <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
-      Version 2.001;GOOG;noto-emoji:20170825:2d38dc415826
+      Version 2.002;GOOG;noto-emoji:20170827:fe2ced85011f
     </namerecord>
     <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
       NotoColorEmoji


### PR DESCRIPTION
The previous release of the font used some incorrect sequences due to
the presence of old png image data in the sources.