### PR TITLE
Update fontRevision, fix git commit id.

### DIFF
--- a/NotoColorEmoji.tmpl.ttx.tmpl
+++ b/NotoColorEmoji.tmpl.ttx.tmpl
@@ -78,7 +78,7 @@
   <head>
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="1.0"/>
-    <fontRevision value="2.003"/>
+    <fontRevision value="2.004"/>
     <checkSumAdjustment value="0x4d5a161a"/>
     <magicNumber value="0x5f0f3cf5"/>
     <flags value="00000000 00001011"/>
@@ -246,7 +246,7 @@
       Noto Color Emoji
     </namerecord>
     <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
-      Version 2.004;GOOG;noto-emoji:20171216:09d8fd121a6d
+      Version 2.004;GOOG;noto-emoji:20180102:8bd8a303c391
     </namerecord>
     <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
       NotoColorEmoji


### PR DESCRIPTION
Previously forgot to update fontRevision when updating the name table
version string.  Also, the commit date/id in the string was created before the
actual pushed commits, so were not correct.  This fixes that.

The version string remains at 2.004 and now the fontRevision matches.